### PR TITLE
Fix FDR SEP Panic and a13 iPhone 11 family devices Rose fix

### DIFF
--- a/src/recovery.c
+++ b/src/recovery.c
@@ -225,9 +225,15 @@ int recovery_enter_restore(struct idevicerestore_client_t* client, plist_t build
 		return -1;
 	}
 
-	if (build_identity_has_component(build_identity, "RestoreSEP")) {
+	if (build_identity_has_component(build_identity, "RestoreDCP") && build_identity_has_component(build_identity, "RestoreSEP")) {
 		/* send rsepfirmware and load it */
 		if (recovery_send_component_and_command(client, build_identity, "RestoreSEP", "rsepfirmware") < 0) {
+			error("ERROR: Unable to send RestoreSEP\n");
+			return -1;
+		}
+	}
+	else {
+		if (recovery_send_component_and_command(client, build_identity, "RestoreSEP", "firmware") < 0) {
 			error("ERROR: Unable to send RestoreSEP\n");
 			return -1;
 		}


### PR DESCRIPTION
Fix FDR SEP Panic Issue affecting a11-13 possibly also affecting a7-a10(not confirmed)
Also fix Rose fatal error during restore for iPhone 11 family of devices, doesn't affect SE 2.